### PR TITLE
feat: Add logic for dynamically rendering the different Toolbox steps

### DIFF
--- a/client/components/ToolboxPage/ToolboxEnd.jsx
+++ b/client/components/ToolboxPage/ToolboxEnd.jsx
@@ -1,0 +1,5 @@
+export default function ToolboxEnd() {
+  return (
+    <h1 className="h1">Toolbox End!</h1>
+  )
+}

--- a/client/components/ToolboxPage/ToolboxStep1.jsx
+++ b/client/components/ToolboxPage/ToolboxStep1.jsx
@@ -1,0 +1,5 @@
+export default function ToolboxStep1() {
+  return (
+    <h1 className="h1">Toolbox Step 1</h1>
+  );
+}

--- a/client/components/ToolboxPage/ToolboxStep2.jsx
+++ b/client/components/ToolboxPage/ToolboxStep2.jsx
@@ -1,0 +1,5 @@
+export default function ToolboxStep2() {
+  return (
+    <h1 className="h1">Toolbox Step 2</h1>
+  )
+}

--- a/client/components/ToolboxPage/ToolboxStep3.jsx
+++ b/client/components/ToolboxPage/ToolboxStep3.jsx
@@ -1,0 +1,5 @@
+export default function ToolboxStep3() {
+  return (
+    <h1 className="h1">Toolbox Step 3</h1>
+  )
+}

--- a/client/components/ToolboxPage/ToolboxStep4.jsx
+++ b/client/components/ToolboxPage/ToolboxStep4.jsx
@@ -1,0 +1,5 @@
+export default function ToolboxStep4() {
+  return (
+    <h1 className="h1">Toolbox Step 4</h1>
+  )
+}

--- a/client/pages/toolbox.js
+++ b/client/pages/toolbox.js
@@ -1,12 +1,20 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useApi } from "@/hooks/useApi";
 import ErrorAlert from "@/components/ErrorAlert";
 import Layout from "@/components/Layout";
+import ToolboxStep1 from "@/components/ToolboxPage/ToolboxStep1";
+import ToolboxStep2 from "@/components/ToolboxPage/ToolboxStep2";
+import ToolboxStep3 from "@/components/ToolboxPage/ToolboxStep3";
+import ToolboxStep4 from "@/components/ToolboxPage/ToolboxStep4";
+import ToolboxEnd from "@/components/ToolboxPage/ToolboxEnd";
+import Button from "@/components/Button";
 
 export default function Toolbox() {
   const [jobDescription, setJobDescription] = useState("");
   const [keywords, setKeywords] = useState([]);
   const { request, loading, error } = useApi();
+  const [toolboxActive, setToolboxActive] = useState(true);
+  const [activeStep, setActiveStep] = useState(1);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -22,10 +30,56 @@ export default function Toolbox() {
     }
   };
 
+  const decrementStep = () => {
+    if (activeStep > 1) {
+      setActiveStep(activeStep - 1);
+    }
+    return;
+  };
+
+  const incrementStep = () => {
+    if (activeStep < 5) {
+      setActiveStep(activeStep + 1);
+    }
+    return;
+  };
+
+  useEffect(() => {
+    if (activeStep > 4) {
+      setToolboxActive(false);
+    }
+  }, [activeStep])
+
+  const renderStep = () => {
+    switch (activeStep) {
+      case 1:
+        return <ToolboxStep1 />;
+      case 2:
+        return <ToolboxStep2 />;
+      case 3:
+        return <ToolboxStep3 />;
+      case 4:
+        return <ToolboxStep4 />;
+    }
+  };
+
   return (
     <Layout>
       <div className="min-h-screen flex flex-col items-center justify-center bg-neutral">
-        <div className="bg-tertiary p-8 rounded shadow-md w-96">
+        {toolboxActive ? (
+          <div className="flex flex-col items-center justify-between bg-grey p-8 rounded-md h-96 w-1/2">
+            <div className="w-full">{renderStep()}</div>
+
+            <div className="flex w-full justify-between">
+              <Button text={"prev"} onClick={decrementStep} />
+              <Button text={"next"} onClick={incrementStep} />
+            </div>
+          </div>
+        ) : (
+          <ToolboxEnd />
+        )}
+
+        {/* <div className="bg-tertiary p-8 rounded shadow-md w-96">
           <h1 className="text-2xl mb-4">Keyword Extractor</h1>
 
           {error && <ErrorAlert errorMessage={error} />}
@@ -58,7 +112,7 @@ export default function Toolbox() {
               </ul>
             </div>
           )}
-        </div>
+        </div> */}
       </div>
     </Layout>
   );


### PR DESCRIPTION
## Description

This PR introduces logic that handles dynamically rendering the different steps of the Toolbox page, as well as new Toolbox Steps components

## Changes Made 

### 1. Toolbox Step Components

- Added the following components: ToolboxStep1, ToolboxStep2, ToolboxStep3, ToolboxStep4, ToolboxEnd
- ToolboxStep1: This will display the step for pasting the Job Description
- ToolboxStep2: This will display the step for the user to see and be able to copy-paste/save the keywords
- ToolboxStep3: This will display the step for pasting the Resume
- ToolboxStep: This will display the step for the user to see and be able to copy-paste/save the bullet points
- ToolboxEnd: This will display the motivating message to the user when they are done with the Toolbox :)

### 2. Toolbox Step Rendering

- Added state for tracking/ adjusting which step is active.
- Added logic for dynamically rendering the different Toolbox steps using the 'prev' and 'next' buttons at the bottom. These buttons currently increment or decrement the active step, but eventually the logic will be refactored to use the back button and submit buttons as laid out in the wireframe.
- Added logic to track whether the Toolbox form is active or not, if it's active the different Toolbox steps are rendered, if its not active the ToolboxEnd component is displayed. This will eventually be a component that is displayed for a few seconds, and then it will redirect to the home page.

## Screenshots
<img width="1463" alt="Screen Shot 2024-08-21 at 9 55 05 AM" src="https://github.com/user-attachments/assets/791a8094-c6b5-4f9d-a6f8-6d0959baeccd">

- Clicking the next button will continue to bring you to each following step until you reach the end.

<img width="200" alt="Screen Shot 2024-08-21 at 9 57 33 AM" src="https://github.com/user-attachments/assets/ca24c4d9-3048-4bfb-b393-b946e0a7a689">
<img width="200" alt="Screen Shot 2024-08-21 at 9 57 43 AM" src="https://github.com/user-attachments/assets/af3b193c-f624-434f-a6b3-f387e0f1e41c">
<img width="200" alt="Screen Shot 2024-08-21 at 9 58 00 AM" src="https://github.com/user-attachments/assets/bac90e7d-adee-447a-808b-34a1f74c9054">
<img width="1062" alt="Screen Shot 2024-08-21 at 9 58 13 AM" src="https://github.com/user-attachments/assets/1caa1fab-7af4-4a40-9973-635e9f600137">



## Additional Context

- This is currently just a skeleton of how the Toolbox will be built, so it will continue to be refined as the development process continues.