### PR TITLE
feat: Add features to Toolbox Step 2, Back Button, and styling updates

### DIFF
--- a/client/components/ToolboxPage/BackButton.jsx
+++ b/client/components/ToolboxPage/BackButton.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import Image from "next/image";
+import BackArrow from "@/public/assets/Back.svg";
+
+export default function BackButton() {
+  return (
+    <Image
+      src={BackArrow}
+      alt="Back Arrow"
+      width={40}
+      height={40}
+      className="hover:opacity-50 hover:cursor-pointer"
+    />
+  );
+}

--- a/client/components/ToolboxPage/Keyword.jsx
+++ b/client/components/ToolboxPage/Keyword.jsx
@@ -1,0 +1,7 @@
+export default function Keyword({ word }) {
+  return (
+    <div className="bg-dark-grey w-fit rounded p-[.5em] text-neutral body-txt">
+      <p>{word}</p>
+    </div>
+  );
+}

--- a/client/components/ToolboxPage/ToolboxStep1.jsx
+++ b/client/components/ToolboxPage/ToolboxStep1.jsx
@@ -7,17 +7,21 @@ const toolboxStep1FormData = {
 
 export default function ToolboxStep1({ handleSubmit, jobDescription, setJobDescription, loading }) {
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-4 h-full">
       <h4 className="h4">Paste a job description below...</h4>
 
-      <form onSubmit={handleSubmit} className="flex flex-col items-center w-full">
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col items-center w-full h-full justify-between"
+      >
         <textarea
-          className="w-full p-6 rounded overflow-scroll mb-6"
-          rows="10"
+          className="w-full p-6 rounded overflow-scroll mb-4"
+          rows="11"
           placeholder={toolboxStep1FormData.placeholderText}
           value={jobDescription}
           onChange={(e) => setJobDescription(e.target.value)}
         ></textarea>
+
         <Button type="submit" text={loading ? "Extracting..." : "Submit"} disabled={loading} />
       </form>
     </div>

--- a/client/components/ToolboxPage/ToolboxStep2.jsx
+++ b/client/components/ToolboxPage/ToolboxStep2.jsx
@@ -21,8 +21,11 @@ export default function ToolboxStep2({ keywords, handleDone, incrementStep }) {
               {word}
             </Keyword>
           ))}
-          <button className="bg-neutral p-2 rounded" onClick={handleShowAll}>
-            Show More
+          <button
+            className="bg-neutral p-[.5em] rounded body-txt hover:text-primary"
+            onClick={handleShowAll}
+          >
+            {showAll ? "Show Less" : "Show More"}
           </button>
         </div>
       </div>

--- a/client/components/ToolboxPage/ToolboxStep2.jsx
+++ b/client/components/ToolboxPage/ToolboxStep2.jsx
@@ -1,12 +1,35 @@
-export default function ToolboxStep2({ keywords }) {
-  return (
-    <div className="flex flex-col gap-6">
-      <h4 className="h4">Get Keywords</h4>
+import { useState } from "react";
+import Button from "../Button";
+import Keyword from "./Keyword";
 
-      <div>
-        {keywords.map((word, idx) => (
-          <p key={idx}>{word}</p>
-        ))}
+export default function ToolboxStep2({ keywords, handleDone, incrementStep }) {
+  const [showAll, setShowAll] = useState(false);
+  const initialKeywordCount = 10;
+
+  const handleShowAll = () => {
+    setShowAll(!showAll);
+  };
+
+  return (
+    <div className="flex flex-col gap-4 justify-between h-full">
+      <div className="flex flex-col gap-4">
+        <h4 className="h4">Get Keywords</h4>
+
+        <div className="flex flex-wrap gap-2">
+          {keywords.slice(0, showAll ? keywords.length : initialKeywordCount).map((word, idx) => (
+            <Keyword word={word} key={idx}>
+              {word}
+            </Keyword>
+          ))}
+          <button className="bg-neutral p-2 rounded" onClick={handleShowAll}>
+            Show More
+          </button>
+        </div>
+      </div>
+
+      <div className="flex justify-between">
+        <Button text={"I'm done"} onClick={handleDone} />
+        <Button text={"Continue to bullet points..."} onClick={incrementStep} />
       </div>
     </div>
   );

--- a/client/pages/toolbox.js
+++ b/client/pages/toolbox.js
@@ -7,8 +7,8 @@ import ToolboxStep2 from "@/components/ToolboxPage/ToolboxStep2";
 import ToolboxStep3 from "@/components/ToolboxPage/ToolboxStep3";
 import ToolboxStep4 from "@/components/ToolboxPage/ToolboxStep4";
 import ToolboxEnd from "@/components/ToolboxPage/ToolboxEnd";
-import Button from "@/components/Button";
 import ProgressBar from "@/components/ToolboxPage/ProgressBar/ProgressBar";
+import BackButton from "@/components/ToolboxPage/BackButton";
 
 export default function Toolbox() {
   const [jobDescription, setJobDescription] = useState("");
@@ -33,6 +33,10 @@ export default function Toolbox() {
     } catch (error) {
       console.error("Failed to extract keywords", error);
     }
+  };
+
+  const handleDone = () => {
+    setActiveStep(5);
   };
 
   const decrementStep = () => {
@@ -67,7 +71,9 @@ export default function Toolbox() {
           />
         );
       case 2:
-        return <ToolboxStep2 keywords={keywords} />;
+        return (
+          <ToolboxStep2 keywords={keywords} handleDone={handleDone} incrementStep={incrementStep} />
+        );
       case 3:
         return <ToolboxStep3 />;
       case 4:
@@ -80,31 +86,22 @@ export default function Toolbox() {
       <div className="min-h-screen flex flex-col gap-10 items-center justify-center bg-neutral">
         {error && <ErrorAlert errorMessage={error} />}
         {toolboxActive ? (
-          <div className="flex flex-col items-center gap-10 w-3/5 h-[40rem] mt-10">
+          <div className="flex flex-col items-center gap-10 w-3/5 h-[40rem] max-h-[40rem] mt-10">
             <ProgressBar activeStep={activeStep} />
 
-            <div className="flex flex-col items-center justify-between bg-grey p-8 rounded-md h-full w-5/6">
-              <div className="w-full">{renderStep()}</div>
+            <div className="flex flex-col items-center justify-between relative bg-grey p-8 rounded-md h-full w-5/6">
+              {activeStep > 1 && (
+                <div className="absolute -left-16" onClick={decrementStep}>
+                  <BackButton />
+                </div>
+              )}
+
+              <div className="w-full h-full">{renderStep()}</div>
             </div>
           </div>
         ) : (
           <ToolboxEnd />
         )}
-
-        {/* <div className="bg-tertiary p-8 rounded shadow-md w-96">
-          <h1 className="text-2xl mb-4">Keyword Extractor</h1>
-
-          {keywords?.length > 0 && (
-            <div className="mt-4">
-              <h2 className="text-xl">Extracted Keywords:</h2>
-              <ul className="mt-2 bg-neutral p-2 rounded list-disc list-inside">
-                {keywords.map((keyword, index) => (
-                  <li key={index}>{keyword}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div> */}
       </div>
     </Layout>
   );

--- a/client/public/assets/Back.svg
+++ b/client/public/assets/Back.svg
@@ -1,0 +1,9 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<rect width="28" height="28" fill="url(#pattern0_769_381)"/>
+<defs>
+<pattern id="pattern0_769_381" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_769_381" transform="scale(0.0111111)"/>
+</pattern>
+<image id="image0_769_381" width="90" height="90" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFoAAABaCAYAAAA4qEECAAAACXBIWXMAAAsTAAALEwEAmpwYAAABOUlEQVR4nO3asUoDURRF0ROLOwr+txYiaW38CIvgH1kJokLKyEAqC4Wgb/TOWjBdII/N4SXFJAAAAAD8N1OSmyTPSd6T3CW5WPpQHSPvkhw+PXNsfjny/Lz+1Jes3fRF5Pl5WfqAa4h8SHK79CHXEHl3/BwnqiQP30R+THJ+6hcQkUewZJF7KHeyyC2UJYvcQlmyyC2UJYvcQlmyyC2UJYvcQlmyyC2UJYvcQlmyyC2UJYvcwuTlljGuvUE0xpM3iIRu5crVMcbkx3Cc8h9a7JbKssVuqSxb7JbKssVuqSxb7JbKssVuqSxb7JbKssVuqSxb7JbKssVuqSxb7JbKsscReyAv6fyx2NuRB1pz7Lckm6UPuYbY+yRnSx9wDbHvlz5Y19jb43WxP0a+XPpQnW3cywAAAJDOPgCEQhT7smKmsQAAAABJRU5ErkJggg=="/>
+</defs>
+</svg>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -12,6 +12,7 @@ module.exports = {
       tertiary: "#EAEAFD",
       "error-state": "#EC473C",
       neutral: "#FFFFFF",
+      "dark-grey": "#A6A6A6",
       grey: "#F2F4F5",
     },
     fontSize: {


### PR DESCRIPTION
## Description
- **What**: This PR introduces added features to Toolbox Step 2, a Back Button for the Toolbox, and various styling updates.
- **Why**: These changes enhance user interaction with the Toolbox, provide navigation options, and ensure consistent styling across steps.

## Changes Made
- **Toolbox Step 2**:
  - Created a reusable `Keyword` component.
  - Added logic for "Show All/Show Less" button functionality.
  - Implemented initial logic for the "I'm Done" button.
  - Added logic for the "Continue to bullet points..." button.

- **Toolbox**:
  - Added a `handleDone` function to manage logic when the user clicks the "I'm Done" button.
  - Introduced a Back Button to allow users to return to the previous step if the current step is higher than the first.

- **Style**:
  - Added dark grey color to the Tailwind config.
  - Updated styling for Toolbox Step 1 to ensure consistency with Step 2.

- **Cleanup**:
  - Removed unused and commented code.

## Screenshots
<img width="1007" alt="Screen Shot 2024-08-27 at 10 51 13 AM" src="https://github.com/user-attachments/assets/bd663e1d-2fb3-42d4-9cbb-2e5bfcc8a53f">
<img width="894" alt="Screen Shot 2024-08-27 at 10 51 34 AM" src="https://github.com/user-attachments/assets/f35f3e6e-3b3e-4905-bc91-343edc9c0c22">

<img width="919" alt="Screen Shot 2024-08-27 at 10 49 53 AM" src="https://github.com/user-attachments/assets/65c0a66f-9e87-4c25-86c7-074f5b5e3b7e">
*Simple styling update to Toolbox Step 1, the gaps between elements were shortened, and the button is now in alignment to where there are in Toolbox Step 2 for a smooth UX

## Additional Notes
- A future feature will include a pop-up to confirm that the user is done and warn them that they will lose their progress if they click the "I'm Done" button.
