### PR TITLE
Add Featured Blog Section to Homepage

### DIFF
--- a/client/components/LandingPage/BlogSection/BlogCard.jsx
+++ b/client/components/LandingPage/BlogSection/BlogCard.jsx
@@ -1,0 +1,31 @@
+import Image from "next/image";
+import Link from "next/link";
+import { urlFor } from "@/src/sanity/lib/image";
+
+const BlogCard = ({ title, body, slug, mainImage }) => (
+  <div className="bg-white/20 rounded-lg overflow-hidden shadow-md flex flex-col h-full">
+    <div className="w-full h-48 sm:h-56 md:h-64 lg:h-48 xl:h-56 relative">
+      {mainImage ? (
+        <Image
+          src={urlFor(mainImage).url()}
+          alt={mainImage.alt || title}
+          fill
+          className="object-cover"
+        />
+      ) : (
+        <div className="w-full h-full flex items-center justify-center bg-gray-200">
+          <span className="text-gray-400 text-4xl">🖼️</span>
+        </div>
+      )}
+    </div>
+    <div className="p-4 sm:p-6 flex flex-col flex-grow">
+      <h3 className="text-lg sm:text-xl font-semibold text-primary mb-2">{title}</h3>
+      <p className="text-gray-700 mb-4 text-sm sm:text-base flex-grow line-clamp-3">{body}</p>
+      <Link href={slug.current} className="text-primary hover:underline text-sm mt-auto">
+        Read more
+      </Link>
+    </div>
+  </div>
+);
+
+export default BlogCard;

--- a/client/components/LandingPage/BlogSection/BlogSection.jsx
+++ b/client/components/LandingPage/BlogSection/BlogSection.jsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import BlogCard from "./BlogCard";
+
+export default function BlogSection({ blogs }) {
+  return (
+    <section className="py-12 mb-12 sm:py-16 w-full">
+      <div className="container mx-auto px-4">
+        <h2 className="text-3xl sm:text-4xl font-bold text-center text-secondary mb-8 sm:mb-12">
+          Featured Blogs
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 sm:gap-8">
+          {blogs.map((blog, index) => (
+            <BlogCard key={index} {...blog} />
+          ))}
+        </div>
+        <div className="text-center mt-8 sm:mt-12">
+          <Link
+            href="/blog"
+            className="text-primary hover:underline inline-block px-6 py-2 border border-primary rounded-full transition-colors duration-300 hover:bg-primary hover:text-white"
+          >
+            See more blogs
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -9,6 +9,9 @@ const nextConfig = {
         port: "",
         pathname: "/a/**",
       },
+      {
+        hostname: "cdn.sanity.io",
+      },
     ],
   },
 };

--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -3,6 +3,7 @@ import DemoSection from "@/components/LandingPage/DemoSection/DemoSection";
 import Hero from "@/components/LandingPage/Hero";
 import FeaturesSection from "@/components/LandingPage/FeaturesSection/FeaturesSection";
 import { client } from "@/src/sanity/lib/client";
+import BlogSection from "@/components/LandingPage/BlogSection/BlogSection";
 
 export default function Home({ HomePageData }) {
   return (
@@ -11,17 +12,28 @@ export default function Home({ HomePageData }) {
       <Hero {...HomePageData.hero} />
       <FeaturesSection {...HomePageData.features} />
       <DemoSection {...HomePageData.demo} />
+      <BlogSection blogs={HomePageData.blogs} />
     </div>
   );
 }
 
 export async function getStaticProps() {
-  const HomePageData = await client.fetch("*[_type == 'homepage'][0]");
+  const HomePageData = await client.fetch(`
+    *[_type == 'homepage'][0]{
+      ...,
+      "blogs": *[_type == 'blog' && featured == true] | order(publishedAt desc)[0...3]{
+        title,
+        "body": array::join(string::split(pt::text(body), "")[0..200], "") + "...",
+        slug,
+        mainImage
+      }
+    }
+  `);
 
   return {
     props: {
       HomePageData,
     },
-    revalidate: 30, // Revalidate every 30 seconds
+    revalidate: 30,
   };
 }

--- a/client/src/sanity/schemaTypes/blogType.js
+++ b/client/src/sanity/schemaTypes/blogType.js
@@ -12,6 +12,11 @@ export const blogType = defineType({
       type: "string",
     }),
     defineField({
+      name: "featured",
+      type: "boolean",
+      description: "Check this box if you want this blog to be featured on the homepage",
+    }),
+    defineField({
       name: "slug",
       type: "slug",
       options: {


### PR DESCRIPTION
This PR introduces a new "Featured Articles" section to the homepage, showcasing up to three featured blog posts. The implementation includes:

- New BlogSection component with responsive design
- Updated homepage query to fetch featured blog posts
- Styling consistent with the overall site design

Key features:
- Displays blog title, truncated content, and featured image
- Responsive grid layout (1 column on mobile, 2 on tablet, 3 on desktop)
- "Read more" link for each blog post
- "See more articles" button linking to the full blog page