### PR TITLE
feat: Add About Page Schemas and Field Validations

### DIFF
--- a/client/src/sanity/schemas/aboutPageType.js
+++ b/client/src/sanity/schemas/aboutPageType.js
@@ -1,0 +1,18 @@
+import { defineField, defineType } from "sanity";
+import { DesktopIcon } from "@sanity/icons";
+
+export const aboutPageType = defineType({
+  name: "aboutpage",
+  title: "About Page",
+  type: "document",
+  icon: DesktopIcon,
+  fields: [
+    defineField({ name: "versionName", title: "Version Name", type: "string" }),
+    defineField({
+      name: "description",
+      title: "Description",
+      type: "string",
+      validation: (Rule) => Rule.required().error("Page description is required."),
+    }),
+  ],
+});

--- a/client/src/sanity/schemas/authorType.js
+++ b/client/src/sanity/schemas/authorType.js
@@ -10,6 +10,7 @@ export const authorType = defineType({
     defineField({
       name: "name",
       type: "string",
+      validation: (Rule) => Rule.required().error("Name is required."),
     }),
     defineField({
       name: "image",

--- a/client/src/sanity/schemas/blogType.js
+++ b/client/src/sanity/schemas/blogType.js
@@ -1,5 +1,5 @@
 import { DocumentTextIcon } from "@sanity/icons";
-import { defineArrayMember, defineField, defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 export const blogType = defineType({
   name: "blog",
@@ -10,6 +10,7 @@ export const blogType = defineType({
     defineField({
       name: "title",
       type: "string",
+      validation: (Rule) => Rule.required().error("Title is required."),
     }),
     defineField({
       name: "featured",
@@ -23,13 +24,20 @@ export const blogType = defineType({
         source: "title",
         slugify: (input) => `/blog/${input.toLowerCase().replace(/\s+/g, "-").slice(0, 200)}`,
       },
-      description: "Please ensure the slugs always start with /blog/...",
+      description: (
+        <>
+          Using the generate button is reccomended. Must start with /blog/...
+          <br />
+          ex: /blog/top-tips-on-how-to-succeed
+        </>
+      ),
       validation: (Rule) => Rule.required().error("Slug is required."),
     }),
     defineField({
       name: "author",
       type: "reference",
       to: { type: "author" },
+      validation: (Rule) => Rule.required().error("Author is required."),
     }),
     defineField({
       name: "mainImage",
@@ -44,14 +52,17 @@ export const blogType = defineType({
           title: "Alternative text",
         },
       ],
+      validation: (Rule) => Rule.required().error("Image is required."),
     }),
     defineField({
       name: "publishedAt",
       type: "datetime",
+      validation: (Rule) => Rule.required().error("Publish date is required."),
     }),
     defineField({
       name: "body",
       type: "blockContent",
+      validation: (Rule) => Rule.required().error("Content is required."),
     }),
   ],
   preview: {

--- a/client/src/sanity/schemas/faqType.js
+++ b/client/src/sanity/schemas/faqType.js
@@ -10,10 +10,12 @@ export const faqType = defineType({
     defineField({
       name: "question",
       type: "string",
+      validation: (Rule) => Rule.required().error("Question is required."),
     }),
     defineField({
       name: "answer",
       type: "text",
+      validation: (Rule) => Rule.required().error("Answer is required."),
     }),
   ],
   preview: {

--- a/client/src/sanity/schemas/footerType.js
+++ b/client/src/sanity/schemas/footerType.js
@@ -5,10 +5,12 @@ export const footerType = defineType({
   title: "Footer",
   type: "document",
   fields: [
+    defineField({ name: "versionName", title: "Version Name", type: "string" }),
     defineField({
       name: "description",
       title: "Description",
       type: "text",
+      validation: (Rule) => Rule.required().error("Description is required."),
     }),
     defineField({
       name: "links",
@@ -45,6 +47,7 @@ export const footerType = defineType({
         { name: "email", title: "Email", type: "string" },
         { name: "phone", title: "Phone", type: "string" },
       ],
+      validation: (Rule) => Rule.required().error("Contact information is required."),
     }),
     defineField({
       name: "socialLinks",
@@ -62,4 +65,9 @@ export const footerType = defineType({
       ],
     }),
   ],
+  preview: {
+    select: {
+      title: "versionName",
+    },
+  },
 });

--- a/client/src/sanity/schemas/homePageType.js
+++ b/client/src/sanity/schemas/homePageType.js
@@ -13,10 +13,30 @@ export const homePageType = defineType({
       title: "Hero Section",
       type: "object",
       fields: [
-        { name: "title", title: "Title", type: "string" },
-        { name: "gradientTitle", title: "Gradient Title", type: "string" },
-        { name: "description", title: "Description", type: "text" },
-        { name: "ctaText", title: "CTA Button Text", type: "string" },
+        {
+          name: "title",
+          title: "Title",
+          type: "string",
+          validation: (Rule) => Rule.required().error("Title is required."),
+        },
+        {
+          name: "gradientTitle",
+          title: "Gradient Title",
+          type: "string",
+          validation: (Rule) => Rule.required().error("Gradient title is required."),
+        },
+        {
+          name: "description",
+          title: "Description",
+          type: "text",
+          validation: (Rule) => Rule.required().error("Description is required."),
+        },
+        {
+          name: "ctaText",
+          title: "CTA Button Text",
+          type: "string",
+          validation: (Rule) => Rule.required().error("CTA text is required."),
+        },
       ],
       options: {
         collapsed: true,
@@ -27,7 +47,12 @@ export const homePageType = defineType({
       title: "Features Section",
       type: "object",
       fields: [
-        { name: "title", title: "Title", type: "string" },
+        {
+          name: "title",
+          title: "Title",
+          type: "string",
+          validation: (Rule) => Rule.required().error("Title is required."),
+        },
         {
           name: "featureItems",
           title: "Feature Items",
@@ -36,28 +61,25 @@ export const homePageType = defineType({
             {
               type: "object",
               fields: [
-                { name: "title", title: "Title", type: "string" },
-                { name: "description", title: "Description", type: "string" },
+                {
+                  name: "title",
+                  title: "Title",
+                  type: "string",
+                  validation: (Rule) => Rule.required().error("Title is required."),
+                },
+                {
+                  name: "description",
+                  title: "Description",
+                  type: "string",
+                  validation: (Rule) => Rule.required().error("Description is required."),
+                },
                 { name: "icon", title: "Feature Icon", type: "image", options: { hotspot: true } },
                 { name: "iconAlt", title: "Feature Icon Alt Text", type: "string" },
               ],
             },
           ],
+          validation: (Rule) => Rule.required().error("Feature items required."),
         },
-      ],
-      options: {
-        collapsed: true,
-      },
-    }),
-    defineField({
-      name: "demo",
-      title: "Demo Section",
-      type: "object",
-      fields: [
-        { name: "title", title: "Title", type: "string" },
-        { name: "description", title: "Description", type: "text" },
-        { name: "checkboxItems", title: "CheckboxItems", type: "array", of: [{ type: "string" }] },
-        { name: "demoImage", title: "Demo Image", type: "image", options: { hotspot: true } },
       ],
       options: {
         collapsed: true,
@@ -72,8 +94,18 @@ export const homePageType = defineType({
           type: "object",
           name: "demo",
           fields: [
-            { name: "title", title: "Title", type: "string" },
-            { name: "description", title: "Description", type: "text" },
+            {
+              name: "title",
+              title: "Title",
+              type: "string",
+              validation: (Rule) => Rule.required().error("Title is required."),
+            },
+            {
+              name: "description",
+              title: "Description",
+              type: "text",
+              validation: (Rule) => Rule.required().error("Description is required."),
+            },
             {
               name: "highlights",
               title: "Highlights",
@@ -82,18 +114,35 @@ export const homePageType = defineType({
                 {
                   type: "object",
                   fields: [
-                    { name: "text", type: "string" },
+                    {
+                      name: "text",
+                      type: "string",
+                      validation: (Rule) => Rule.required().error("Text is required."),
+                    },
                     {
                       name: "icon",
                       type: "image",
                       options: { hotspot: true },
+                      validation: (Rule) => Rule.required().error("Image is required."),
                     },
-                    { name: "iconAlt", title: "Highlight Icon Alt Text", type: "string" },
+                    {
+                      name: "iconAlt",
+                      title: "Highlight Icon Alt Text",
+                      type: "string",
+                      validation: (Rule) => Rule.required().error("Alt text is required."),
+                    },
                   ],
                 },
               ],
+              validation: (Rule) => Rule.required().error("Highlights are required."),
             },
-            { name: "demoImage", title: "Demo Image", type: "image", options: { hotspot: true } },
+            {
+              name: "demoImage",
+              title: "Demo Image",
+              type: "image",
+              options: { hotspot: true },
+              validation: (Rule) => Rule.required().error("Demo image is required."),
+            },
             { name: "imageLeft", title: "Align the image to the left?", type: "boolean" },
           ],
         },
@@ -107,11 +156,36 @@ export const homePageType = defineType({
         {
           type: "object",
           fields: [
-            { name: "quote", title: "Quote", type: "string" },
-            { name: "text", title: "Text", type: "text" },
-            { name: "name", title: "Name", type: "string" },
-            { name: "title", title: "Title", type: "string" },
-            { name: "year", title: "Year", type: "number" },
+            {
+              name: "quote",
+              title: "Quote",
+              type: "string",
+              validation: (Rule) => Rule.required().error("Quote is required."),
+            },
+            {
+              name: "text",
+              title: "Text",
+              type: "text",
+              validation: (Rule) => Rule.required().error("Text is required."),
+            },
+            {
+              name: "name",
+              title: "Name",
+              type: "string",
+              validation: (Rule) => Rule.required().error("Name is required."),
+            },
+            {
+              name: "title",
+              title: "Title",
+              type: "string",
+              validation: (Rule) => Rule.required().error("Title is required."),
+            },
+            {
+              name: "year",
+              title: "Year",
+              type: "number",
+              validation: (Rule) => Rule.required().error("Year is required."),
+            },
           ],
         },
       ],

--- a/client/src/sanity/schemas/index.js
+++ b/client/src/sanity/schemas/index.js
@@ -4,7 +4,9 @@ import { authorType } from "./authorType";
 import { homePageType } from "./homePageType";
 import { faqType } from "./faqType";
 import { footerType } from "./footerType";
+import { aboutPageType } from "./aboutPageType";
+import { teamMemberType } from "./teamMemberType";
 
 export const schema = {
-  types: [blockContentType, blogType, authorType, faqType, homePageType, footerType],
+  types: [blockContentType, blogType, authorType, faqType, homePageType, footerType, aboutPageType, teamMemberType],
 };

--- a/client/src/sanity/schemas/teamMemberType.js
+++ b/client/src/sanity/schemas/teamMemberType.js
@@ -1,0 +1,61 @@
+import { UserIcon } from "@sanity/icons";
+import { defineField, defineType } from "sanity";
+
+export const teamMemberType = defineType({
+  name: "teamMember",
+  title: "Team Member",
+  type: "document",
+  icon: UserIcon,
+  fields: [
+    defineField({
+      name: "name",
+      title: "Name",
+      type: "string",
+      validation: (Rule) => Rule.required().error('Name is required.'),
+    }),
+    defineField({
+      name: "role",
+      title: "Role",
+      type: "string",
+      validation: (Rule) => Rule.required().error('Role is required.'),
+    }),
+    defineField({
+      name: "student",
+      title: "Is the Team Member a Student?",
+      type: "boolean",
+    }),
+    defineField({
+      name: "studentInformation",
+      type: "object",
+      fields: [
+        { name: "school", title: "School", type: "string" },
+        { name: "major", title: "Major", type: "string" },
+        { name: "graduation", title: "Graduation", type: "string" },
+      ],
+      hidden: ({ parent }) => parent?.student === false,
+    }),
+    defineField({
+      name: "teamMemberInformation",
+      title: "Team Member Information",
+      type: "object",
+      fields: [
+        { name: "company", title: "Company", type: "string" },
+        { name: "responsibilities", title: "Responsibilities", type: "text" },
+      ],
+      hidden: ({ parent }) => parent?.student === true,
+    }),
+    defineField({
+      name: "socialMediaLinks",
+      title: "Social Media Links",
+      type: "object",
+      fields: [
+        { name: "linkedIn", title: "LinkedIn", type: "string" },
+        { name: "gitHub", title: "Git Hub", type: "string" },
+        { name: "website", title: "Website", type: "string" },
+      ],
+      options: {
+        collapsed: true,
+      },
+    }),
+  ],
+});

--- a/client/src/sanity/structure.js
+++ b/client/src/sanity/structure.js
@@ -3,12 +3,13 @@ export const structure = (S) =>
   S.list()
     .title("Website")
     .items([
-      S.documentTypeListItem("blog").title("Blog"),
       S.documentTypeListItem("author").title("Authors"),
+      S.documentTypeListItem("teamMember").title("Team Members"),
+      S.documentTypeListItem("blog").title("Blog"),
       S.documentTypeListItem("faq").title("Frequently Asked Questions"),
       S.divider(),
       S.documentTypeListItem("homepage").title("Home Page"),
-      // S.documentTypeListItem("about").title("About Page"),
+      S.documentTypeListItem("aboutpage").title("About Page"),
       S.divider(),
       S.documentTypeListItem("footer").title("Footer"),
     ]);


### PR DESCRIPTION
## Description
This PR introduces schemas for the **About Page** and adds validation to required fields across multiple Sanity schemas, ensuring data integrity and usability.

---

## Changes Made

### About Page Schemas
- **`teamMemberType` Schema**:
  - Introduced a `student` boolean field to dynamically load either student-specific fields or general team member fields.
  - Added flexibility for managing team data with tailored fields.
- **`aboutPageType` Schema**:
  - Structured to support dynamic content for the About page.

### Field Validations
- **`blogType` Schema**:
  - Added validation to required fields.
  - Updated the `slug` field description for better clarity.
- **`authorType` Schema**:
  - Added validation to required fields.
- **`faqType` Schema**:
  - Added validation to required fields.
- **`footerType` Schema**:
  - Added validation to required fields.
  - Introduced a `versionName` field to manage version tracking.
- **`homePageType` Schema**:
  - Added validation to required fields.
  - Removed the old/unused Demo Section field, as it has been replaced by the new `demoOverview` field.

---

## Additional Notes
- The new `teamMemberType` schema enables dynamic field handling for student and general team members, streamlining data management.
- **Future Consideration**: Consolidating the `authorType` and `teamMemberType` schemas could simplify the structure. This would involve refactoring `blogType` to reference `teamMemberType` instead.
